### PR TITLE
docs: add new /project endpoints, change tags response body

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,265 +1,290 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <meta charset="utf-8" />
-    <meta content="IE=edge,chrome=1" http-equiv="X-UA-Compatible" />
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1, maximum-scale=1"
-    />
-    <title>API Reference</title>
 
-    <style>
-      .highlight table td {
-        padding: 5px;
-      }
-      .highlight table pre {
-        margin: 0;
-      }
-      .highlight,
-      .highlight .w {
-        color: #f8f8f2;
-        background-color: #272822;
-      }
-      .highlight .err {
-        color: #272822;
-        background-color: #f92672;
-      }
-      .highlight .c,
-      .highlight .cd,
-      .highlight .cm,
-      .highlight .c1,
-      .highlight .cs {
-        color: #75715e;
-      }
-      .highlight .cp {
-        color: #f4bf75;
-      }
-      .highlight .nt {
-        color: #f4bf75;
-      }
-      .highlight .o,
-      .highlight .ow {
-        color: #f8f8f2;
-      }
-      .highlight .p,
-      .highlight .pi {
-        color: #f8f8f2;
-      }
-      .highlight .gi {
-        color: #a6e22e;
-      }
-      .highlight .gd {
-        color: #f92672;
-      }
-      .highlight .gh {
-        color: #66d9ef;
-        background-color: #272822;
-        font-weight: bold;
-      }
-      .highlight .k,
-      .highlight .kn,
-      .highlight .kp,
-      .highlight .kr,
-      .highlight .kv {
-        color: #ae81ff;
-      }
-      .highlight .kc {
-        color: #fd971f;
-      }
-      .highlight .kt {
-        color: #fd971f;
-      }
-      .highlight .kd {
-        color: #fd971f;
-      }
-      .highlight .s,
-      .highlight .sb,
-      .highlight .sc,
-      .highlight .sd,
-      .highlight .s2,
-      .highlight .sh,
-      .highlight .sx,
-      .highlight .s1 {
-        color: #a6e22e;
-      }
-      .highlight .sr {
-        color: #a1efe4;
-      }
-      .highlight .si {
-        color: #cc6633;
-      }
-      .highlight .se {
-        color: #cc6633;
-      }
-      .highlight .nn {
-        color: #f4bf75;
-      }
-      .highlight .nc {
-        color: #f4bf75;
-      }
-      .highlight .no {
-        color: #f4bf75;
-      }
-      .highlight .na {
-        color: #66d9ef;
-      }
-      .highlight .m,
-      .highlight .mf,
-      .highlight .mh,
-      .highlight .mi,
-      .highlight .il,
-      .highlight .mo,
-      .highlight .mb,
-      .highlight .mx {
-        color: #a6e22e;
-      }
-      .highlight .ss {
-        color: #a6e22e;
-      }
-    </style>
-    <link href="stylesheets/screen.css" rel="stylesheet" media="screen" />
-    <link href="stylesheets/print.css" rel="stylesheet" media="print" />
-    <script src="javascripts/all.js"></script>
-  </head>
+<head>
+  <meta charset="utf-8" />
+  <meta content="IE=edge,chrome=1" http-equiv="X-UA-Compatible" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
+  <title>API Reference</title>
 
-  <body class="index" data-languages="[]">
-    <a href="http://lang.ai" id="nav-button">
-      <span>
-        NAV
-        <img src="images/navbar.png" alt="Navbar" />
-      </span>
-    </a>
-    <div class="tocify-wrapper">
-      <a href="http://lang.ai" title="Go to Lang.AI website"
-        ><img src="images/logo-lang.svg" class="logo" alt="Logo"
-      /></a>
-      <div class="search">
-        <input
-          type="text"
-          class="search"
-          id="input-search"
-          placeholder="Search"
-        />
-      </div>
-      <ul class="search-results"></ul>
-      <div id="toc"></div>
-      <ul class="toc-footer">
-        <li><a href="https://help.lang.ai">Help Center</a></li>
-      </ul>
+  <style>
+    .highlight table td {
+      padding: 5px;
+    }
+
+    .highlight table pre {
+      margin: 0;
+    }
+
+    .highlight,
+    .highlight .w {
+      color: #f8f8f2;
+      background-color: #272822;
+    }
+
+    .highlight .err {
+      color: #272822;
+      background-color: #f92672;
+    }
+
+    .highlight .c,
+    .highlight .cd,
+    .highlight .cm,
+    .highlight .c1,
+    .highlight .cs {
+      color: #75715e;
+    }
+
+    .highlight .cp {
+      color: #f4bf75;
+    }
+
+    .highlight .nt {
+      color: #f4bf75;
+    }
+
+    .highlight .o,
+    .highlight .ow {
+      color: #f8f8f2;
+    }
+
+    .highlight .p,
+    .highlight .pi {
+      color: #f8f8f2;
+    }
+
+    .highlight .gi {
+      color: #a6e22e;
+    }
+
+    .highlight .gd {
+      color: #f92672;
+    }
+
+    .highlight .gh {
+      color: #66d9ef;
+      background-color: #272822;
+      font-weight: bold;
+    }
+
+    .highlight .k,
+    .highlight .kn,
+    .highlight .kp,
+    .highlight .kr,
+    .highlight .kv {
+      color: #ae81ff;
+    }
+
+    .highlight .kc {
+      color: #fd971f;
+    }
+
+    .highlight .kt {
+      color: #fd971f;
+    }
+
+    .highlight .kd {
+      color: #fd971f;
+    }
+
+    .highlight .s,
+    .highlight .sb,
+    .highlight .sc,
+    .highlight .sd,
+    .highlight .s2,
+    .highlight .sh,
+    .highlight .sx,
+    .highlight .s1 {
+      color: #a6e22e;
+    }
+
+    .highlight .sr {
+      color: #a1efe4;
+    }
+
+    .highlight .si {
+      color: #cc6633;
+    }
+
+    .highlight .se {
+      color: #cc6633;
+    }
+
+    .highlight .nn {
+      color: #f4bf75;
+    }
+
+    .highlight .nc {
+      color: #f4bf75;
+    }
+
+    .highlight .no {
+      color: #f4bf75;
+    }
+
+    .highlight .na {
+      color: #66d9ef;
+    }
+
+    .highlight .m,
+    .highlight .mf,
+    .highlight .mh,
+    .highlight .mi,
+    .highlight .il,
+    .highlight .mo,
+    .highlight .mb,
+    .highlight .mx {
+      color: #a6e22e;
+    }
+
+    .highlight .ss {
+      color: #a6e22e;
+    }
+  </style>
+  <link href="stylesheets/screen.css" rel="stylesheet" media="screen" />
+  <link href="stylesheets/print.css" rel="stylesheet" media="print" />
+  <script src="javascripts/all.js"></script>
+</head>
+
+<body class="index" data-languages="[]">
+  <a href="http://lang.ai" id="nav-button">
+    <span>
+      NAV
+      <img src="images/navbar.png" alt="Navbar" />
+    </span>
+  </a>
+  <div class="tocify-wrapper">
+    <a href="http://lang.ai" title="Go to Lang.AI website"><img src="images/logo-lang.svg" class="logo"
+        alt="Logo" /></a>
+    <div class="search">
+      <input type="text" class="search" id="input-search" placeholder="Search" />
     </div>
-    <div class="page-wrapper">
-      <div class="dark-box"></div>
-      <div class="content">
-        <h1 id="workflow">Workflow</h1>
+    <ul class="search-results"></ul>
+    <div id="toc"></div>
+    <ul class="toc-footer">
+      <li><a href="https://help.lang.ai">Help Center</a></li>
+    </ul>
+  </div>
+  <div class="page-wrapper">
+    <div class="dark-box"></div>
+    <div class="content">
+      <h1 id="workflow">Workflow</h1>
 
-        <p>
-          Lang.ai algorithm adapts to any language, industry or business case
-          given the adequate training data. The typical workflow for using
-          lang.ai API is the following:
-        </p>
+      <p>
+        Lang.ai algorithm adapts to any language, industry or business case
+        given the adequate training data. The typical workflow for using
+        lang.ai API is the following:
+      </p>
 
-        <ul>
-          <li>
-            In order to build a custom classifier you will need to create a project passing a dataset. This can be any collection of customer interactions or any
-            other type of text.
-          </li>
-          <li>
-            The algorithm will automatically extract intents and features that
-            that you can group in tags inside your project section.
-          </li>
-          <li>
-            Once the project is successfully created, the lang.ai API can be used
-            in real time to analyze and save new documents (e.g. support tickets, chatbot messages, etc.) in your project.
-          </li>
-        </ul>
+      <ul>
+        <li>
+          In order to build a custom classifier you will need to create a project passing a dataset. This can be any
+          collection of customer interactions or any
+          other type of text.
+        </li>
+        <li>
+          The algorithm will automatically extract intents and features that
+          that you can group in tags inside your project section.
+        </li>
+        <li>
+          Once the project is successfully created, the lang.ai API can be used
+          in real time to analyze and save new documents (e.g. support tickets, chatbot messages, etc.) in your project.
+        </li>
+      </ul>
 
-        <h1 id="the-api">The API</h1>
+      <h1 id="the-api">The API</h1>
 
-        <p>
-          The API is organized around REST. It has predictable,
-          resource-oriented URLs, and uses HTTP response codes to indicate API
-          errors. We use built-in HTTP features, like HTTP authentication and
-          HTTP verbs, which are understood by off-the-shelf HTTP clients. JSON
-          is returned by all API responses, including errors, although the API
-          libraries convert responses to appropriate language-specific objects.
-        </p>
+      <p>
+        The API is organized around REST. It has predictable,
+        resource-oriented URLs, and uses HTTP response codes to indicate API
+        errors. We use built-in HTTP features, like HTTP authentication and
+        HTTP verbs, which are understood by off-the-shelf HTTP clients. JSON
+        is returned by all API responses, including errors, although the API
+        libraries convert responses to appropriate language-specific objects.
+      </p>
 
-        <p>The service is available at "https://company.lang.ai/api/v1". Replace the example domain with the one you are using in your Lang.ai instance.</p>
+      <p>The service is available at "https://company.lang.ai/api/v1". Replace the example domain with the one you are
+        using in your Lang.ai instance.</p>
 
-        <h1 id="authentication">Authentication</h1>
-        <pre
-          class="highlight shell"
-        ><code>curl https://company.lang.ai/api/v1/analyze <span class="se">\</span>
+      <h1 id="authentication">Authentication</h1>
+      <pre class="highlight shell"><code>curl https://company.lang.ai/api/v1/analyze <span class="se">\</span>
   -H <span class="s2">"Authorization: Bearer YOUR_TOKEN"</span> <span class="se">\</span>
   -H <span class="s2">"Content-Type: application/json"</span> <span class="se">\</span>
   -X POST -d <span class="s1">'{"text": "The Text", "projectId": "YOUR_PROJECT_ID"}'</span>
 </code></pre>
-        <p>
-          Authenticate your account when using the API by including your secret
-          API token in every request. You can create a new API token from the Settings section in your Lang.ai instance. Do not share your
-          secret API tokens in publicly accessible areas such GitHub,
-          client-side code, and so forth.
-        </p>
+      <p>
+        Authenticate your account when using the API by including your secret
+        API token in every request. You can create a new API token from the Settings section in your Lang.ai instance.
+        Do not share your
+        secret API tokens in publicly accessible areas such GitHub,
+        client-side code, and so forth.
+      </p>
 
-        <p>
-          Keep in mind that generating a new token will invalidate the previously issued ones.
-        </p>
+      <p>
+        Keep in mind that generating a new token will invalidate the previously issued ones.
+      </p>
 
-        <p>Every request must be authenticated with the your API token.</p>
+      <p>Every request must be authenticated with the your API token.</p>
 
-        <h1 id="rate-limit">Rate Limit</h1>
+      <h1 id="rate-limit">Rate Limit</h1>
 
-        <p>
-          To avoid abuse and ensure that the system remains online for every
-          user, every API request will need to provide valid credentials and the
-          requests can be rate limited if they exceed the limitations.
-				</p>
+      <p>
+        To avoid abuse and ensure that the system remains online for every
+        user, every API request will need to provide valid credentials and the
+        requests can be rate limited if they exceed the limitations.
+      </p>
 
-				<h1 id="create">Create projects</h1>
+      <h1 id="create">Create projects</h1>
 
-				<p>
-				This API allows you to create a project by performing a single, multipart request containing both project's metadata and
-				the contents of a dataset.
-				</p>
+      <p>
+        This API allows you to create a project by performing a single, multipart request containing both project's
+        metadata and
+        the contents of a dataset.
+      </p>
 
-			<p>To use this multipart upload:</p>
-			<ol>
-				<li>Create a <code>POST</code> request to <code>https://company.lang.ai/api/v1/project</code>.</li>
-				<li>Create the body of the request. Format the body according to the <code>multipart/related</code> content type <a
-						href="http://tools.ietf.org/html/rfc2387" rel="nofollow">RFC 2387</a>, which contains two parts:
-					<ul>
-						<li><strong>Metadata part</strong>. Must come first, and must have a <code>Content-Type</code> header set to
-							<code>application/json; charset=UTF-8</code>. Add the classifier's metadata to this part in JSON format. See the details below.
-						</li>
-						<li><strong>Media part</strong>. Must come second, and must have a <code>Content-Type</code> header, which must
-							have either <code>text/plain</code> or <code>text/csv</code> type. Add the file's data to this part.
-							Identify each part with a boundary string, preceded by two hyphens. In addition, add two hyphens after the final
-							boundary string.</li>
-					</ul>
-				</li>
-				<li>Add the following HTTP headers:
-					<ul>
-						<li><code>Content-Type</code>: <code>multipart/related</code> and include the boundary string to identify each
-							part as a parameter (e.g.: <code>multipart/related; boundary=foo</code>).</li>
-						<li><code>Authorization</code>: <code>Bearer &lt;your-api-token&gt;</code>.</li>
-					</ul>
-				</li>
-				<li>Send the request. Upon success, you'll get a JSON with a single key <code>id</code>, containing the newly created
-					project's id.</li>
-			</ol>
-				</p>
+      <p>To use this multipart upload:</p>
+      <ol>
+        <li>Create a <code>POST</code> request to <code>https://company.lang.ai/api/v1/project</code>.</li>
+        <li>Create the body of the request. Format the body according to the <code>multipart/related</code> content type
+          <a href="http://tools.ietf.org/html/rfc2387" rel="nofollow">RFC 2387</a>, which contains two parts:
+          <ul>
+            <li><strong>Metadata part</strong>. Must come first, and must have a <code>Content-Type</code> header set to
+              <code>application/json; charset=UTF-8</code>. Add the classifier's metadata to this part in JSON format.
+              See the details below.
+            </li>
+            <li><strong>Media part</strong>. Must come second, and must have a <code>Content-Type</code> header, which
+              must
+              have either <code>text/plain</code> or <code>text/csv</code> type. Add the file's data to this part.
+              Identify each part with a boundary string, preceded by two hyphens. In addition, add two hyphens after the
+              final
+              boundary string.</li>
+          </ul>
+        </li>
+        <li>Add the following HTTP headers:
+          <ul>
+            <li><code>Content-Type</code>: <code>multipart/related</code> and include the boundary string to identify
+              each
+              part as a parameter (e.g.: <code>multipart/related; boundary=foo</code>).</li>
+            <li><code>Authorization</code>: <code>Bearer &lt;your-api-token&gt;</code>.</li>
+          </ul>
+        </li>
+        <li>Send the request. Upon success, you'll get a JSON with a single key <code>id</code>, containing the newly
+          created
+          project's id.</li>
+      </ol>
+      </p>
 
-				<p>Please check our <a href="https://gist.github.com/fjaguero/5cf6721d7ea28df7d0eedab74a8a58d8" title="See demo code">Python implementation example</a> that can be used as a starting point.</p>
+      <p>Please check our <a href="https://gist.github.com/fjaguero/5cf6721d7ea28df7d0eedab74a8a58d8"
+          title="See demo code">Python implementation example</a> that can be used as a starting point.</p>
 
-				<h3 id="http-request">HTTP Request</h3>
+      <h3 id="http-request">HTTP Request</h3>
 
-				<p>
-					<code class="prettyprint">POST https://company.lang.ai/api/v1/project</code>
-				</p>
+      <p>
+        <code class="prettyprint">POST https://company.lang.ai/api/v1/project</code>
+      </p>
 
-				<h3 id="request-body">Request Body (multipart/related)</h3>
-<pre class="highlight json"><code><span class="s2"><span class="w"># Boundary string should be replaced</span>
+      <h3 id="request-body">Request Body (multipart/related)</h3>
+      <pre class="highlight json"><code><span class="s2"><span class="w"># Boundary string should be replaced</span>
 b'--{boundary_string}
 Content-Type: application/json; charset=UTF-8
 {
@@ -283,269 +308,563 @@ Second text,2018-04-25
 }
 </span></code></pre>
 
-				<table>
-					<thead>
-						<tr>
-							<th>Parameter</th>
-							<th>Required</th>
-							<th>Type</th>
-							<th>Description</th>
-						</tr>
-					</thead>
-					<tbody>
-						<tr>
-							<td>metadata.name</td>
-							<td>true</td>
-							<td>string</td>
-							<td>The name of the project.</td>
-						</tr>
-						<tr>
-							<td>metadata.csvOptions</td>
-							<td>true</td>
-							<td>object</td>
-							<td>Must be an object with two keys: <p><code>textColumn</code> – The name of the column from the CSV file containing each document's text.</p>
-							<p><code>dateColumn</code> – Optional: the name of the column from the CSV file that contains the document's date.</p></td>
-						</tr>
-						<tr>
-							<td>metadata.team_ids</td>
-							<td>true</td>
-							<td>string[]</td>
-							<td>The list of team id's that will have access to the project.</td>
-						</tr>
-						<tr>
-							<td>media</td>
-							<td>true</td>
-							<td>file</td>
-							<td>The data from the file to be uploaded.</td>
-						</tr>
-					</tbody>
-				</table>
+      <table>
+        <thead>
+          <tr>
+            <th>Parameter</th>
+            <th>Required</th>
+            <th>Type</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>metadata.name</td>
+            <td>true</td>
+            <td>string</td>
+            <td>The name of the project.</td>
+          </tr>
+          <tr>
+            <td>metadata.csvOptions</td>
+            <td>true</td>
+            <td>object</td>
+            <td>Must be an object with two keys: <p><code>textColumn</code> – The name of the column from the CSV file
+                containing each document's text.</p>
+              <p><code>dateColumn</code> – Optional: the name of the column from the CSV file that contains the
+                document's date.</p>
+            </td>
+          </tr>
+          <tr>
+            <td>metadata.team_ids</td>
+            <td>true</td>
+            <td>string[]</td>
+            <td>The list of team id's that will have access to the project.</td>
+          </tr>
+          <tr>
+            <td>media</td>
+            <td>true</td>
+            <td>file</td>
+            <td>The data from the file to be uploaded.</td>
+          </tr>
+        </tbody>
+      </table>
 
-				<h3 id="response-body">Response Body</h3>
+      <h3 id="response-body">Response Body</h3>
 
-				<p>
-					The response returns the id of the project that is being created.
-				</p>
+      <p>
+        The response returns the id of the project that is being created.
+      </p>
 
-				<table>
-					<thead>
-						<tr>
-							<th>Field</th>
-							<th>Type</th>
-							<th>Description</th>
-						</tr>
-					</thead>
-					<tbody>
-						<tr>
-							<td>id</td>
-							<td>string</td>
-							<td>The id of the project.</td>
-						</tr>
-					</tbody>
-				</table>
-				<pre class="highlight json"><code><span class="p">{</span><span class="w"> </span><span class="s2">"id"</span><span class="p">:</span><span class="w"> </span><span class="s2">"project_id"</span><span class="p"></span><span class="w"> </span>}</span><span class="w"> </span></code></pre>
-        <h1 id="analyze">Analyze documents</h1>
+      <table>
+        <thead>
+          <tr>
+            <th>Field</th>
+            <th>Type</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>id</td>
+            <td>string</td>
+            <td>The id of the project.</td>
+          </tr>
+        </tbody>
+      </table>
+      <pre
+        class="highlight json"><code><span class="p">{</span><span class="w"> </span><span class="s2">"id"</span><span class="p">:</span><span class="w"> </span><span class="s2">"project_id"</span><span class="p"></span><span class="w"> </span>}</span><span class="w"> </span></code></pre>
+      <h1 id="list-projects">List projects</h1>
 
-        <p>
-          Returns the classification for a given document and the specified
-          project.
-        </p>
+      <p>
+        Returns the list of projects.
+      </p>
 
-        <h3 id="http-request">HTTP Request</h3>
+      <h3 id="http-request">HTTP Request</h3>
 
-        <p>
-          <code class="prettyprint">POST https://company.lang.ai/api/v1/analyze</code>
-        </p>
+      <p>
+        <code class="prettyprint">GET https://company.lang.ai/api/v1/projects</code>
+      </p>
 
-        <h3 id="request-body">Request Body</h3>
-        <pre
-          class="highlight json"
-        ><code><span class="p">{</span><span class="w">
+      <h3 id="request-body">Request Body</h3>
+
+      <p>
+        The request doesn't require a JSON body.
+      </p>
+
+
+      <h3 id="response-body">Response Body</h3>
+
+      <p>
+        The response returns a list of zero, one or more projects. Each project contains the following fields:
+      </p>
+
+      <pre class="highlight json"><code><span class="w">[</span>
+  <span class="p">{</span><span class="w"></span>
+    <span class="s2">"status"</span><span class="p">:</span><span class="w"> </span><span class="s2">"Processing"</span><span class="p">,</span></span><span class="w">
+    <span class="s2">"id"</span><span class="p">:</span><span class="w"> </span><span class="s2">"sWP2ll1v16lLdMxM"</span><span class="p">,</span></span><span class="w">
+    <span class="s2">"name"</span><span class="p">:</span><span class="w"> </span><span class="s2">"My first project"</span><span class="p">,</span></span><span class="w">
+    <span class="s2">"createdAt"</span><span class="p">:</span><span class="w"> </span><span class="s2">"2021-03-22T13:54:55Z"</span></span>  
+  <span class="w">}</span><span class="w">,</span>
+  <span class="p">{</span><span class="w"></span>
+    <span class="s2">"status"</span><span class="p">:</span><span class="w"> </span><span class="s2">"Completed"</span><span class="p">,</span></span><span class="w">
+    <span class="s2">"id"</span><span class="p">:</span><span class="w"> </span><span class="s2">"l3wNMwIXM1S046Sy"</span><span class="p">,</span></span><span class="w">
+    <span class="s2">"name"</span><span class="p">:</span><span class="w"> </span><span class="s2">"My second project"</span><span class="p">,</span></span><span class="w">
+    <span class="s2">"createdAt"</span><span class="p">:</span><span class="w"> </span><span class="s2">"2021-03-23T13:54:55Z"</span></span>  
+  <span class="w">}</span><span class="w">
+<span class="w">]</span>
+</span></code></pre>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Field</th>
+            <th>Type</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>status</td>
+            <td>string</td>
+            <td>The project status: Errored, Processing, Completed.</td>
+          </tr>
+          <tr>
+            <td>id</td>
+            <td>string</td>
+            <td>
+              The ID of the project.
+            </td>
+          </tr>
+          <tr>
+            <td>name</td>
+            <td>string</td>
+            <td>
+              The name of the project.
+            </td>
+          </tr>
+          <tr>
+            <td>createdAt</td>
+            <td>string</td>
+            <td>
+              The creation date of the project.
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h1 id="list-project-tags">List project tags</h1>
+
+      <p>
+        Returns the list of the project's tags.
+      </p>
+
+      <h3 id="http-request">HTTP Request</h3>
+
+      <p>
+        <code class="prettyprint">GET https://company.lang.ai/api/v1/projects/:projectId</code>
+      </p>
+
+      <h3 id="request-body">Request Body</h3>
+
+      <p>
+        The request doesn't require a JSON body.
+      </p>
+
+
+      <h3 id="response-body">Response Body</h3>
+
+      <p>
+        The response returns the project information as well as the list of zero, one or more <a
+          href="https://help.lang.ai/en/articles/3175538-using-tags" title="Learn more about Tags">tags</a>.
+      </p>
+
+
+      <pre class="highlight json"><code>
+<span class="p">{</span><span class="w"></span>
+  <span class="s2">"status"</span><span class="p">:</span><span class="w"> </span><span class="s2">"Completed"</span><span class="p">,</span></span><span class="w">
+  <span class="s2">"id"</span><span class="p">:</span><span class="w"> </span><span class="s2">"l3wNMwIXM1S046Sy"</span><span class="p">,</span></span><span class="w">
+  <span class="s2">"name"</span><span class="p">:</span><span class="w"> </span><span class="s2">"My second project"</span><span class="p">,</span></span><span class="w">
+  <span class="s2">"createdAt"</span><span class="p">:</span><span class="w"> </span><span class="s2">"2021-03-23T13:54:55Z"</span></span> 
+  <span class="s2">"tags"</span><span class="p">:</span><span class="w"> </span><span class="p">[</span><span
+    class="w"></span><span class="p">{</span><span class="w"></span>
+    <span class="s2">"id"</span><span class="p">:</span><span class="w"> </span><span
+      class="s2">"tqGMbCpTBZOJaram"</span><span class="p">,
+    </span><span class="s2">"name"</span><span class="p">:</span><span class="w"> </span><span
+      class="s2">"My first tag"</span><span class="p">,
+    <span class="s2">"createdAt"</span><span class="p">:</span><span class="w"> </span><span
+      class="s2">"2021-04-21T12:40:50.892265Z"</span><span class="p">,
+    <span class="s2">"updatedAt"</span><span class="p">:</span><span class="w"> </span><span
+      class="s2">"2021-04-25T11:35:43.512464Z"</span><span class="p">,
+    <span class="s2">"isDraft"</span><span class="p">:</span><span class="w"> </span><span
+      class="s2">false</span>
+  <span class="p">}</span><span class="w"></span><span class="p">]</span><span class="w">
+<span class="w">}</span><span class="w">
+</span></code></pre>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Field</th>
+            <th>Type</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>status</td>
+            <td>string</td>
+            <td>The project status: Errored, Processing, Completed.</td>
+          </tr>
+          <tr>
+            <td>id</td>
+            <td>string</td>
+            <td>
+              The ID of the project.
+            </td>
+          </tr>
+          <tr>
+            <td>name</td>
+            <td>string</td>
+            <td>
+              The name of the project.
+            </td>
+          </tr>
+          <tr>
+            <td>createdAt</td>
+            <td>string</td>
+            <td>
+              The creation date of the project.
+            </td>
+          </tr>
+          <tr>
+            <td>tags</td>
+            <td>tag[]</td>
+            <td>
+              An array of tags.
+            </td>
+          </tr>
+          <tr>
+            <td>tag[].id</td>
+            <td>string</td>
+            <td>
+              The ID of the tag.
+            </td>
+          </tr>
+          <tr>
+            <td>tag[].name</td>
+            <td>string</td>
+            <td>
+              The name of the tag.
+            </td>
+          </tr>
+          <tr>
+            <td>tag[].createdAt</td>
+            <td>string</td>
+            <td>
+              The creation date of the tag.
+            </td>
+          </tr>
+          <tr>
+            <td>tag[].updatedAt</td>
+            <td>string</td>
+            <td>
+              The last update date of the tag.
+            </td>
+          </tr>
+          <tr>
+            <td>tag[].isDraft</td>
+            <td>boolean</td>
+            <td>
+              Whether or not the tag is draft. <a href="https://help.lang.ai/en/articles/5046690-using-draft-tags"
+                title="Lear nmore about Draft Tags">Learn more</a>.
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h1 id="analyze">Analyze documents</h1>
+
+      <p>
+        Returns the classification for a given document and the specified
+        project.
+      </p>
+
+      <h3 id="http-request">HTTP Request</h3>
+
+      <p>
+        <code class="prettyprint">POST https://company.lang.ai/api/v1/analyze</code>
+      </p>
+
+      <h3 id="request-body">Request Body</h3>
+      <pre class="highlight json"><code><span class="p">{</span><span class="w">
   </span><span class="s2">"text"</span><span class="p">:</span><span class="w"> </span><span class="s2">"The text to be analyzed"</span><span class="p">,</span><span class="w">
   </span><span class="s2">"projectId"</span><span class="p">:</span><span class="w"> </span><span class="s2">"Your project id"</span><span class="w">
 </span><span class="p">}</span><span class="w">
-</span></code></pre>
-        <table>
-          <thead>
-            <tr>
-              <th>Parameter</th>
-              <th>Required</th>
-              <th>Type</th>
-              <th>Description</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td>text</td>
-              <td>true</td>
-              <td>string</td>
-              <td>The text to be classified.</td>
-            </tr>
-            <tr>
-              <td>projectId</td>
-              <td>true</td>
-              <td>string</td>
-              <td>The project to be used to classify the text.</td>
-            </tr>
-          </tbody>
-        </table>
+  </span></code></pre>
+      <table>
+        <thead>
+          <tr>
+            <th>Parameter</th>
+            <th>Required</th>
+            <th>Type</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>text</td>
+            <td>true</td>
+            <td>string</td>
+            <td>The text to be classified.</td>
+          </tr>
+          <tr>
+            <td>projectId</td>
+            <td>true</td>
+            <td>string</td>
+            <td>The project to be used to classify the text.</td>
+          </tr>
+        </tbody>
+      </table>
 
-        <h3 id="response-body">Response Body</h3>
+      <h3 id="response-body">Response Body</h3>
 
-        <p>
-          The response returns a list of zero, one or more <a href="https://help.lang.ai/en/articles/3175538-using-tags" title="Learn more about Tags">tags</a> and <a href="https://help.lang.ai/en/collections/1565410-technology#intents-and-features" title="Learn more about intents">intents</a>. Each intent
-          contains the following fields:
-        </p>
+      <p>
+        The response returns a list of zero, one or more <a href="https://help.lang.ai/en/articles/3175538-using-tags"
+          title="Learn more about Tags">tags</a> and <a
+          href="https://help.lang.ai/en/collections/1565410-technology#intents-and-features"
+          title="Learn more about intents">intents</a>.
+      </p>
 
-        <table>
-          <thead>
-            <tr>
-              <th>Field</th>
-              <th>Type</th>
-              <th>Description</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td>name</td>
-              <td>string</td>
-              <td>The name of the intent.</td>
-            </tr>
-            <tr>
-              <td>features</td>
-              <td>string[]</td>
-              <td>
-                The list of features. The sign &ldquo;&gt;&rdquo; indicates a
-                second-level feature.
-              </td>
-            </tr>
-          </tbody>
-        </table>
-        <pre
-          class="highlight json"
-        ><code><span class="p">{</span><span class="w">
-  </span><span class="s2">"tags"</span><span class="p">:</span><span class="w"> </span><span class="p">[</span><span class="s2">"Tag 1"</span><span class="p">,</span><span class="w"> </span><span
-    class="s2">"Tag 2"</span><span class="p">]</span><span class="w">
+      <pre class="highlight json"><code><span class="p">{</span><span class="w">
+  </span><span class="s2">"tags"</span><span class="p">:</span><span class="w"> </span><span class="p">[</span><span
+    class="w"></span>
+    <span class="p">{</span><span class="w"></span>
+        <span class="s2">"id"</span><span class="p">:</span><span class="w"> </span><span
+        class="s2">"tqGMbCpTBZOJaram"</span><span class="p">,
+        </span><span class="s2">"name"</span><span class="p">:</span><span class="w"> </span><span class="s2">"My first tag"</span>
+    <span class="p">}</span><span class="w">
+  </span><span class="p">]</span><span class="w"><span class="p">,</span>
   <span class="s2">"intents"</span><span class="p">:</span><span class="w"> </span><span class="p">[</span><span class="w">
     </span><span class="p">{</span><span class="w">
         </span><span class="s2">"name"</span><span class="p">:</span><span class="w"> </span><span class="s2">"intent"</span><span class="p">,</span><span class="w">
-        </span><span class="s2">"features"</span><span class="p">:</span><span class="w"> </span><span class="p">[</span><span class="s2">"feature"</span><span class="p">,</span><span class="w"> </span><span class="s2">"feature&gt;feature"</span><span class="p">],</span><span class="w">
+        </span><span class="s2">"features"</span><span class="p">:</span><span class="w"> </span><span class="p">[</span><span class="s2">"feature"</span><span class="p">,</span><span class="w"> </span><span class="s2">"feature&gt;feature"</span><span class="p">]</span><span class="w">
     </span><span class="p">}</span><span class="w">
   </span><span class="p">]</span><span class="w">
 </span><span class="p">}</span><span class="w">
 </span></code></pre>
-        <h1 id="documents">Save documents</h1>
+      <table>
+        <thead>
+          <tr>
+            <th>Field</th>
+            <th>Type</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>intents</td>
+            <td>intent[]</td>
+            <td>
+              An array of intents.
+            </td>
+          <tr>
+            <td>intent[].name</td>
+            <td>string</td>
+            <td>The name of the intent.</td>
+          </tr>
+          <tr>
+            <td>intent[].features</td>
+            <td>string[]</td>
+            <td>
+              An array of features. The sign &ldquo;&gt;&rdquo; indicates a
+              second-level feature.
+            </td>
+          </tr>
+          <tr>
+            <td>tags</td>
+            <td>tag[]</td>
+            <td>
+              An array of tags.
+            </td>
+          </tr>
+          <tr>
+            <td>tag[].id</td>
+            <td>string</td>
+            <td>
+              The ID of the tag.
+            </td>
+          </tr>
+          <tr>
+            <td>tag[].name</td>
+            <td>string</td>
+            <td>
+              The name of the tag.
+            </td>
+          </tr>
 
-        <p>
-          Saves a given document into the specified project. It supports passing
-          metadata that can be later used in the project's <a href="https://help.lang.ai/en/articles/2724433-getting-started-with-dashboards" title="Learn more about Dashboards">Dashboard</a>. New metadata values passed via API will be available to use in the project's setup section.
-        </p>
+        </tbody>
+      </table>
 
-        <h3 id="http-request">HTTP Request</h3>
+      <h1 id="documents">Save documents</h1>
 
-        <p>
-          <code class="prettyprint">POST https://company.lang.ai/api/v1/documents</code>
-        </p>
+      <p>
+        Saves a given document into the specified project. It supports passing
+        metadata that can be later used in the project's <a
+          href="https://help.lang.ai/en/articles/2724433-getting-started-with-dashboards"
+          title="Learn more about Dashboards">Dashboard</a>. New metadata values passed via API will be available to use
+        in the project's setup section.
+      </p>
 
-        <h3 id="request-body">Request Body</h3>
-        <pre
-          class="highlight json"
-        ><code><span class="p">{</span><span class="w">
+      <h3 id="http-request">HTTP Request</h3>
+
+      <p>
+        <code class="prettyprint">POST https://company.lang.ai/api/v1/documents</code>
+      </p>
+
+      <h3 id="request-body">Request Body</h3>
+      <pre class="highlight json"><code><span class="p">{</span><span class="w">
   </span><span class="s2">"text"</span><span class="p">:</span><span class="w"> </span><span class="s2">"The text to be analyzed"</span><span class="p">,</span><span class="w">
   </span><span class="s2">"projectId"</span><span class="p">:</span><span class="w"> </span><span class="s2">"Your project id"</span><span class="p">,</span><span class="w">
-  <span class="s2">"metadata"</span><span class="p">:</span><span class="w"> </span><span class="s2">{"key": "value"}</span><span class="w"></span><span class="p">,</span><span class="c"> // Optional</span>
+  <span class="s2">"metadata"</span><span class="p">:</span><span class="w"> </span><span class="s2">{"key": "value", "another_key": "value"}</span><span class="w"></span><span class="p">,</span><span class="c"> // Optional</span>
   <span class="s2">"date"</span><span class="p">:</span><span class="w"> </span><span class="s2">"2019-20-12"</span><span class="w"></span><span class="c"> // Optional</span>
 <span class="p">}</span><span class="w">
 </span></code></pre>
-        <table>
-          <thead>
-            <tr>
-              <th>Parameter</th>
-              <th>Required</th>
-              <th>Default</th>
-              <th>Type</th>
-              <th>Description</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td>text</td>
-              <td>true</td>
-              <td>-</td>
-              <td>string</td>
-              <td>The text to be classified.</td>
-            </tr>
-            <tr>
-              <td>projectId</td>
-              <td>true</td>
-              <td>-</td>
-              <td>string</td>
-              <td>The project to be used to classify the text.</td>
-            </tr>
-            <tr>
-              <td>metadata</td>
-              <td>false</td>
-              <td>-</td>
-              <td>object</td>
-              <td>The metadata information of the document.</td>
-            </tr>
-            <tr>
-              <td>date</td>
-              <td>false</td>
-              <td>now</td>
-              <td>string</td>
-              <td>The date of the document. It supports valid IS0 8601 dates. If not passed, the request time is used.</td>
-            </tr>
-          </tbody>
-        </table>
+      <table>
+        <thead>
+          <tr>
+            <th>Parameter</th>
+            <th>Required</th>
+            <th>Default</th>
+            <th>Type</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>text</td>
+            <td>true</td>
+            <td>-</td>
+            <td>string</td>
+            <td>The text to be classified.</td>
+          </tr>
+          <tr>
+            <td>projectId</td>
+            <td>true</td>
+            <td>-</td>
+            <td>string</td>
+            <td>The project to be used to classify the text.</td>
+          </tr>
+          <tr>
+            <td>metadata</td>
+            <td>false</td>
+            <td>-</td>
+            <td>object</td>
+            <td>The metadata information of the document.</td>
+          </tr>
+          <tr>
+            <td>date</td>
+            <td>false</td>
+            <td>now</td>
+            <td>string</td>
+            <td>The date of the document. It supports valid IS0 8601 dates. If not passed, the request time is used.
+            </td>
+          </tr>
+        </tbody>
+      </table>
 
-        <h3 id="response-body">Response Body</h3>
+      <h3 id="response-body">Response Body</h3>
 
-        <p>
-          The request returns a 201 HTTP code when the document is saved
-          successfully.
-        </p>
+      <p>
+        The response returns a list of zero, one or more <a href="https://help.lang.ai/en/articles/3175538-using-tags"
+          title="Learn more about Tags">tags</a> and <a
+          href="https://help.lang.ai/en/collections/1565410-technology#intents-and-features"
+          title="Learn more about intents">intents</a>. Each intent
+        contains the following fields:
+      </p>
 
-        <h1 id="errors">Errors</h1>
+      <table>
+        <thead>
+          <tr>
+            <th>Field</th>
+            <th>Type</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>name</td>
+            <td>string</td>
+            <td>The name of the intent.</td>
+          </tr>
+          <tr>
+            <td>features</td>
+            <td>string[]</td>
+            <td>
+              The list of features. The sign &ldquo;&gt;&rdquo; indicates a
+              second-level feature.
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <pre class="highlight json"><code><span class="p">{</span><span class="w">
+  </span><span class="s2">"tags"</span><span class="p">:</span><span class="w"> </span><span class="p">[</span><span
+    class="w"></span>
+    <span class="p">{</span><span class="w"></span>
+        <span class="s2">"id"</span><span class="p">:</span><span class="w"> </span><span
+        class="s2">"tqGMbCpTBZOJaram"</span><span class="p">,
+        </span><span class="s2">"name"</span><span class="p">:</span><span class="w"> </span><span class="s2">"My first tag"</span>
+    <span class="p">}</span><span class="w">
+  </span><span class="p">]</span><span class="w"><span class="p">,</span>
+  <span class="s2">"intents"</span><span class="p">:</span><span class="w"> </span><span class="p">[</span><span class="w">
+    </span><span class="p">{</span><span class="w">
+        </span><span class="s2">"name"</span><span class="p">:</span><span class="w"> </span><span class="s2">"intent"</span><span class="p">,</span><span class="w">
+        </span><span class="s2">"features"</span><span class="p">:</span><span class="w"> </span><span class="p">[</span><span class="s2">"feature"</span><span class="p">,</span><span class="w"> </span><span class="s2">"feature&gt;feature"</span><span class="p">]</span><span class="w">
+    </span><span class="p">}</span><span class="w">
+  </span><span class="p">]</span><span class="w">
+</span><span class="p">}</span><span class="w">
+</span></code></pre>
 
-        <p>
-          If the request succeeded, the response status will be 200 OK.
-          Otherwise the response status will be 4xx or 5xx as described in the
-          following table:
-        </p>
+      <h1 id="errors">Errors</h1>
 
-        <table>
-          <thead>
-            <tr>
-              <th>Error Code</th>
-              <th>Meaning</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td>400</td>
-              <td>Bad request / Missing fields</td>
-            </tr>
-            <tr>
-              <td>401</td>
-              <td>Unauthorized</td>
-            </tr>
-            <tr>
-              <td>404</td>
-              <td>Project not found</td>
-            </tr>
-            <tr>
-              <td>429</td>
-              <td>Too many requests / Rate limited</td>
-            </tr>
-            <tr>
-              <td>500</td>
-              <td>Internal server error</td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-      <div class="dark-box"></div>
+      <p>
+        If the request succeeded, the response status will be 200 OK.
+        Otherwise the response status will be 4xx or 5xx as described in the
+        following table:
+      </p>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Error Code</th>
+            <th>Meaning</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>400</td>
+            <td>Bad request / Missing fields</td>
+          </tr>
+          <tr>
+            <td>401</td>
+            <td>Unauthorized</td>
+          </tr>
+          <tr>
+            <td>404</td>
+            <td>Project not found</td>
+          </tr>
+          <tr>
+            <td>429</td>
+            <td>Too many requests / Rate limited</td>
+          </tr>
+          <tr>
+            <td>500</td>
+            <td>Internal server error</td>
+          </tr>
+        </tbody>
+      </table>
     </div>
-  </body>
+    <div class="dark-box"></div>
+  </div>
+</body>
+
 </html>


### PR DESCRIPTION
Two new endpoints have been introduced:
— /projects: returns the list of projects
— /projects/{project_id}: returns the project details and the list of its tags
The /analyze endpoints now returns the id and name of the tags instead of only the name
The /documents endpoint now returns the analysis (same as /analyze) of the document after saving it, instead of an empty response
